### PR TITLE
feat : enable and disable kafka listener

### DIFF
--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/config/GlobalExceptionHandler.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/config/GlobalExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.example.springbootkafkasample.config;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    ProblemDetail onException(MethodArgumentNotValidException methodArgumentNotValidException) {
+        ProblemDetail problemDetail =
+                ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(400), "Invalid request content.");
+        problemDetail.setTitle("Constraint Violation");
+        List<ApiValidationError> validationErrorsList = methodArgumentNotValidException.getAllErrors().stream()
+                .map(objectError -> {
+                    FieldError fieldError = (FieldError) objectError;
+                    return new ApiValidationError(
+                            fieldError.getObjectName(),
+                            fieldError.getField(),
+                            fieldError.getRejectedValue(),
+                            Objects.requireNonNull(fieldError.getDefaultMessage(), ""));
+                })
+                .sorted(Comparator.comparing(ApiValidationError::field))
+                .toList();
+        problemDetail.setProperty("violations", validationErrorsList);
+        return problemDetail;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    ProblemDetail handleIllegalArgumentException(IllegalArgumentException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(400), ex.getMessage());
+        problemDetail.setTitle("Bad Request");
+        return problemDetail;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ProblemDetail handleInvalidEnum(HttpMessageNotReadableException ex) {
+        if (ex.getMessage()
+                .contains("Cannot deserialize value of type `com.example.springbootkafkasample.dto.Operation`")) {
+            return ProblemDetail.forStatusAndDetail(
+                    HttpStatusCode.valueOf(400), "Invalid operation value. Allowed values are: START, STOP.");
+        }
+        return ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(400), "Invalid request.");
+    }
+
+    record ApiValidationError(String object, String field, Object rejectedValue, String message) {}
+}

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/config/KafkaConfig.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/config/KafkaConfig.java
@@ -8,6 +8,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListenerConfigurer;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.lang.NonNull;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 @Configuration
@@ -23,7 +24,7 @@ public class KafkaConfig implements KafkaListenerConfigurer {
     }
 
     @Override
-    public void configureKafkaListeners(KafkaListenerEndpointRegistrar registrar) {
+    public void configureKafkaListeners(@NonNull KafkaListenerEndpointRegistrar registrar) {
         registrar.setValidator(this.validator);
     }
 

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/controller/MessageRestController.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/controller/MessageRestController.java
@@ -5,6 +5,12 @@ import com.example.springbootkafkasample.dto.MessageDTO;
 import com.example.springbootkafkasample.dto.TopicInfo;
 import com.example.springbootkafkasample.service.MessageService;
 import com.example.springbootkafkasample.service.sender.Sender;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
@@ -27,13 +33,24 @@ public class MessageRestController {
 
     @GetMapping("/listeners")
     public ResponseEntity<Map<String, Boolean>> getListeners() {
-        return ResponseEntity.ok(messageService.getListeners());
+        return ResponseEntity.ok(messageService.getListenersState());
     }
 
+    @Operation(summary = "Update the state of a Kafka listener")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Listener state updated successfully",
+                        content =
+                                @Content(mediaType = "application/json", schema = @Schema(implementation = Map.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+                @ApiResponse(responseCode = "404", description = "Listener not found", content = @Content)
+            })
     @PostMapping("/listeners")
-    public ResponseEntity<Map<String, Boolean>> getListeners(
-            @RequestBody final KafkaListenerRequest kafkaListenerRequest) {
-        return ResponseEntity.ok(messageService.getListeners(kafkaListenerRequest));
+    public ResponseEntity<Map<String, Boolean>> updateListenerState(
+            @RequestBody @Valid final KafkaListenerRequest kafkaListenerRequest) {
+        return ResponseEntity.ok(messageService.updateListenerState(kafkaListenerRequest));
     }
 
     @PostMapping("/messages")

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/controller/MessageRestController.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/controller/MessageRestController.java
@@ -1,10 +1,13 @@
 package com.example.springbootkafkasample.controller;
 
+import com.example.springbootkafkasample.dto.KafkaListenerRequest;
 import com.example.springbootkafkasample.dto.MessageDTO;
 import com.example.springbootkafkasample.dto.TopicInfo;
 import com.example.springbootkafkasample.service.MessageService;
 import com.example.springbootkafkasample.service.sender.Sender;
 import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +23,17 @@ public class MessageRestController {
     public MessageRestController(Sender sender, MessageService messageService) {
         this.sender = sender;
         this.messageService = messageService;
+    }
+
+    @GetMapping("/listeners")
+    public ResponseEntity<Map<String, Boolean>> getListeners() {
+        return ResponseEntity.ok(messageService.getListeners());
+    }
+
+    @PostMapping("/listeners")
+    public ResponseEntity<Map<String, Boolean>> getListeners(
+            @RequestBody final KafkaListenerRequest kafkaListenerRequest) {
+        return ResponseEntity.ok(messageService.getListeners(kafkaListenerRequest));
     }
 
     @PostMapping("/messages")

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/KafkaListenerRequest.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/KafkaListenerRequest.java
@@ -1,0 +1,3 @@
+package com.example.springbootkafkasample.dto;
+
+public record KafkaListenerRequest(String containerId, Operation operation) {}

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/KafkaListenerRequest.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/KafkaListenerRequest.java
@@ -1,3 +1,8 @@
 package com.example.springbootkafkasample.dto;
 
-public record KafkaListenerRequest(String containerId, Operation operation) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record KafkaListenerRequest(
+        @NotBlank(message = "Container ID must not be blank") String containerId,
+        @NotNull(message = "Operation must not be null") Operation operation) {}

--- a/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/Operation.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/java/com/example/springbootkafkasample/dto/Operation.java
@@ -1,0 +1,6 @@
+package com.example.springbootkafkasample.dto;
+
+public enum Operation {
+    START,
+    STOP
+}

--- a/kafka-spring-boot/boot-kafka-sample/src/main/resources/application.properties
+++ b/kafka-spring-boot/boot-kafka-sample/src/main/resources/application.properties
@@ -8,4 +8,6 @@ spring.kafka.consumer.properties.spring.json.trusted.packages=com.example.spring
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.UUIDSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
 spring.threads.virtual.enabled=true
+spring.mvc.problemdetails.enabled=true

--- a/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleApplicationTests.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleApplicationTests.java
@@ -2,15 +2,12 @@ package com.example.springbootkafkasample;
 
 import static com.example.springbootkafkasample.config.Initializer.TOPIC_TEST_1;
 import static com.example.springbootkafkasample.config.Initializer.TOPIC_TEST_2;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.springbootkafkasample.dto.MessageDTO;
 import com.example.springbootkafkasample.service.listener.Receiver2;
-import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -65,15 +62,6 @@ class KafkaSampleApplicationTests {
                         messageListenerContainer, embeddedKafkaBroker.getPartitionsPerTopic());
             }
         }
-    }
-
-    @Test
-    void sendAndReceiveData() throws InterruptedException {
-        template.send(TOPIC_TEST_1, UUID.randomUUID(), new MessageDTO(TOPIC_TEST_1, "foo"));
-        // 4 from topic1 and 3 from topic2 on startUp, plus 1 from test
-        await().pollInterval(Duration.ofSeconds(1))
-                .atMost(Duration.ofSeconds(45))
-                .untilAsserted(() -> assertThat(receiver2.getLatch().getCount()).isEqualTo(9));
     }
 
     @Test

--- a/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleIntegrationTest.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleIntegrationTest.java
@@ -9,7 +9,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.springbootkafkasample.common.ContainerConfig;
+import com.example.springbootkafkasample.dto.KafkaListenerRequest;
 import com.example.springbootkafkasample.dto.MessageDTO;
+import com.example.springbootkafkasample.dto.Operation;
 import com.example.springbootkafkasample.service.listener.Receiver2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -23,7 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(classes = TestBootKafkaSampleApplication.class)
+@SpringBootTest(classes = ContainerConfig.class)
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class KafkaSampleIntegrationTest {
@@ -40,6 +43,7 @@ class KafkaSampleIntegrationTest {
     @Test
     @Order(1)
     void sendAndReceiveMessage() throws Exception {
+        long initialCount = receiver2.getLatch().getCount();
         this.mockMvc
                 .perform(post("/messages")
                         .content(this.objectMapper.writeValueAsString(new MessageDTO("test_1", "junitTest")))
@@ -49,7 +53,7 @@ class KafkaSampleIntegrationTest {
         // 4 from topic1 and 3 from topic2 on startUp, plus 1 from test
         await().pollInterval(Duration.ofSeconds(1))
                 .atMost(Duration.ofSeconds(30))
-                .untilAsserted(() -> assertThat(receiver2.getLatch().getCount()).isEqualTo(7));
+                .untilAsserted(() -> assertThat(receiver2.getLatch().getCount()).isEqualTo(initialCount + 3));
         assertThat(receiver2.getDeadLetterLatch().getCount()).isEqualTo(1);
     }
 
@@ -96,5 +100,64 @@ class KafkaSampleIntegrationTest {
                 .andExpect(jsonPath("$[6].topicName").value("test_3"))
                 .andExpect(jsonPath("$[6].partitionCount").value(32))
                 .andExpect(jsonPath("$[6].replicationCount").value(1));
+    }
+
+    @Test
+    void getListOfContainers() throws Exception {
+        this.mockMvc
+                .perform(get("/listeners"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(5))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-dlt']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-1']")
+                        .value(true));
+    }
+
+    @Test
+    void stopAndStartContainers() throws Exception {
+        this.mockMvc
+                .perform(post("/listeners")
+                        .content(this.objectMapper.writeValueAsString(new KafkaListenerRequest(
+                                "org.springframework.kafka.KafkaListenerEndpointContainer#1-dlt", Operation.STOP)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(5))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-dlt']")
+                        .value(false))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-1']")
+                        .value(true));
+        this.mockMvc
+                .perform(post("/listeners")
+                        .content(this.objectMapper.writeValueAsString(new KafkaListenerRequest(
+                                "org.springframework.kafka.KafkaListenerEndpointContainer#1-dlt", Operation.START)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(5))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-dlt']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-0']")
+                        .value(true))
+                .andExpect(jsonPath("$.['org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-1']")
+                        .value(true));
     }
 }

--- a/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleIntegrationTest.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/KafkaSampleIntegrationTest.java
@@ -43,7 +43,6 @@ class KafkaSampleIntegrationTest {
     @Test
     @Order(1)
     void sendAndReceiveMessage() throws Exception {
-        long initialCount = receiver2.getLatch().getCount();
         this.mockMvc
                 .perform(post("/messages")
                         .content(this.objectMapper.writeValueAsString(new MessageDTO("test_1", "junitTest")))
@@ -52,8 +51,8 @@ class KafkaSampleIntegrationTest {
 
         // 4 from topic1 and 3 from topic2 on startUp, plus 1 from test
         await().pollInterval(Duration.ofSeconds(1))
-                .atMost(Duration.ofSeconds(30))
-                .untilAsserted(() -> assertThat(receiver2.getLatch().getCount()).isEqualTo(initialCount + 3));
+                .atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> assertThat(receiver2.getLatch().getCount()).isEqualTo(7));
         assertThat(receiver2.getDeadLetterLatch().getCount()).isEqualTo(1);
     }
 

--- a/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/TestBootKafkaSampleApplication.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/TestBootKafkaSampleApplication.java
@@ -1,27 +1,13 @@
 package com.example.springbootkafkasample;
 
+import com.example.springbootkafkasample.common.ContainerConfig;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
-import org.testcontainers.kafka.KafkaContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@TestConfiguration(proxyBeanMethods = false)
 public class TestBootKafkaSampleApplication {
-
-    @Bean
-    @ServiceConnection
-    KafkaContainer kafkaContainer() {
-        KafkaContainer kafkaContainer =
-                new KafkaContainer(DockerImageName.parse("apache/kafka-native").withTag("3.8.0"));
-        kafkaContainer.addEnv("KAFKA_NUM_PARTITIONS", "32");
-        return kafkaContainer;
-    }
 
     public static void main(String[] args) {
         SpringApplication.from(BootKafkaSampleApplication::main)
-                .with(TestBootKafkaSampleApplication.class)
+                .with(ContainerConfig.class)
                 .run(args);
     }
 }

--- a/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/common/ContainerConfig.java
+++ b/kafka-spring-boot/boot-kafka-sample/src/test/java/com/example/springbootkafkasample/common/ContainerConfig.java
@@ -1,0 +1,20 @@
+package com.example.springbootkafkasample.common;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class ContainerConfig {
+
+    @Bean
+    @ServiceConnection
+    KafkaContainer kafkaContainer() {
+        KafkaContainer kafkaContainer =
+                new KafkaContainer(DockerImageName.parse("apache/kafka-native").withTag("3.8.1"));
+        kafkaContainer.addEnv("KAFKA_NUM_PARTITIONS", "32");
+        return kafkaContainer;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced two new API endpoints for managing Kafka listeners: one for retrieving the current listeners and another for starting or stopping them based on requests.
  - Added a new data structure to encapsulate listener requests, enhancing the request handling process.
  - Introduced an enumeration to represent operational states (START and STOP) for better control of Kafka listeners.
  - Implemented centralized exception handling for improved error reporting and validation feedback.

- **Bug Fixes**
  - Removed an outdated test method that was no longer necessary, streamlining the testing process.

- **Tests**
  - Enhanced integration tests for Kafka listeners, including new test cases for retrieving and managing listener states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->